### PR TITLE
move out stylus plugin require to be compatible with npm link

### DIFF
--- a/tasks/client.js
+++ b/tasks/client.js
@@ -31,9 +31,7 @@ module.exports = function (gulp, config) {
         .pipe(plumber())
         .pipe(gulpif(!isProduction, sourcemaps.init()))
         .pipe(stylus({
-          use: config.client.stylesheets.plugins.map(function(pluginName) {
-            return require(pluginName)()
-          }),
+          use: config.client.stylesheets.plugins,
           compress: isProduction
         }))
         .pipe(gulpif(


### PR DESCRIPTION
require command doesnt find packages when in different folder because of npm link, require should be in application gulpfile
